### PR TITLE
rTorrent 0.9

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ rtorrent_default_directories:
     group: "{{ rtorrent_group }}"
 
 rtorrent_schedule_watch_directory: watch_directory,5,5,load.start={{ rtorrent_directory_watch }}/*.torrent
-rtorrent_schedule_untied_directory: untied_directory,5,5,stop.untied=
+rtorrent_schedule_untied_directory: untied_directory,5,5,stop_untied=
 
 rtorrent_port_range: 46157-47169
 rtorrent_port_random: "yes"

--- a/README.md
+++ b/README.md
@@ -27,12 +27,22 @@ rtorrent_max_uploads: 15
 rtorrent_download_rate: 0
 rtorrent_upload_rate: 0
 
-rtorrent_directory_download: "{{ rtorrent_user_home }}/download"
-rtorrent_directory_session: "{{ rtorrent_user_home }}/session"
-rtorrent_directory_watch: "{{ rtorrent_user_home }}/watch"
+rtorrent_default_directories:
+  download:
+    path: "{{ rtorrent_user_home }}/download"
+    user: "{{ rtorrent_user }}"
+    group: "{{ rtorrent_group }}"
+  session:
+    path: "{{ rtorrent_user_home }}/session"
+    user: "{{ rtorrent_user }}"
+    group: "{{ rtorrent_group }}"
+  watch:
+    path: "{{ rtorrent_user_home }}/watch"
+    user: "{{ rtorrent_user }}"
+    group: "{{ rtorrent_group }}"
 
-rtorrent_schedule_watch_directory: watch_directory,5,5,load_start={{ rtorrent_directory_watch }}/*.torrent
-rtorrent_schedule_untied_directory: untied_directory,5,5,stop_untied=
+rtorrent_schedule_watch_directory: watch_directory,5,5,load.start={{ rtorrent_directory_watch }}/*.torrent
+rtorrent_schedule_untied_directory: untied_directory,5,5,stop.untied=
 
 rtorrent_port_range: 46157-47169
 rtorrent_port_random: "yes"

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,11 +17,21 @@ rtorrent_max_uploads: 15
 rtorrent_download_rate: 0
 rtorrent_upload_rate: 0
 
-rtorrent_directory_download: "{{ rtorrent_user_home }}/download"
-rtorrent_directory_session: "{{ rtorrent_user_home }}/session"
-rtorrent_directory_watch: "{{ rtorrent_user_home }}/watch"
+rtorrent_directories:
+  download:
+    path: "{{ rtorrent_user_home }}/download"
+    user: "{{ rtorrent_user }}"
+    group: "{{ rtorrent_group }}"
+  session:
+    path: "{{ rtorrent_user_home }}/session"
+    user: "{{ rtorrent_user }}"
+    group: "{{ rtorrent_group }}"
+  watch:
+    path: "{{ rtorrent_user_home }}/watch"
+    user: "{{ rtorrent_user }}"
+    group: "{{ rtorrent_group }}"
 
-rtorrent_schedule_watch_directory: watch_directory,5,5,load_start={{ rtorrent_directory_watch }}/*.torrent
+rtorrent_schedule_watch_directory: watch_directory,5,5,load_start={{ rtorrent_directories.watch.path }}/*.torrent
 rtorrent_schedule_untied_directory: untied_directory,5,5,stop_untied=
 
 rtorrent_port_range_start: 46157

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,7 +17,7 @@ rtorrent_max_uploads: 15
 rtorrent_download_rate: 0
 rtorrent_upload_rate: 0
 
-rtorrent_directories:
+rtorrent_default_directories:
   download:
     path: "{{ rtorrent_user_home }}/download"
     user: "{{ rtorrent_user }}"
@@ -30,6 +30,8 @@ rtorrent_directories:
     path: "{{ rtorrent_user_home }}/watch"
     user: "{{ rtorrent_user }}"
     group: "{{ rtorrent_group }}"
+
+rtorrent_combined_directories: "{{ rtorrent_default_directories | combine(rtorrent_directories, recursive=True) }}"
 
 rtorrent_schedule_watch_directory: watch_directory,5,5,load_start={{ rtorrent_directories.watch.path }}/*.torrent
 rtorrent_schedule_untied_directory: untied_directory,5,5,stop_untied=

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -34,7 +34,7 @@ rtorrent_default_directories:
 rtorrent_combined_directories: "{{ rtorrent_default_directories | combine(rtorrent_directories, recursive=True) }}"
 
 rtorrent_schedule_watch_directory: watch_directory,5,5,load.start={{ rtorrent_directories.watch.path }}/*.torrent
-rtorrent_schedule_untied_directory: untied_directory,5,5,stop.untied=
+rtorrent_schedule_untied_directory: untied_directory,5,5,stop_untied=
 
 rtorrent_port_range_start: 46157
 rtorrent_port_range_end: 47169

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,8 +33,8 @@ rtorrent_default_directories:
 
 rtorrent_combined_directories: "{{ rtorrent_default_directories | combine(rtorrent_directories, recursive=True) }}"
 
-rtorrent_schedule_watch_directory: watch_directory,5,5,load_start={{ rtorrent_directories.watch.path }}/*.torrent
-rtorrent_schedule_untied_directory: untied_directory,5,5,stop_untied=
+rtorrent_schedule_watch_directory: watch_directory,5,5,load.start={{ rtorrent_directories.watch.path }}/*.torrent
+rtorrent_schedule_untied_directory: untied_directory,5,5,stop.untied=
 
 rtorrent_port_range_start: 46157
 rtorrent_port_range_end: 47169

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -37,9 +37,9 @@
     owner: "{{ item.user  }}"
     group: "{{ item.group }}"
   with_items:
-    - "{{ rtorrent_directories.download }}"
-    - "{{ rtorrent_directories.session }}"
-    - "{{ rtorrent_directories.watch }}"
+    - "{{ rtorrent_combined_directories.download }}"
+    - "{{ rtorrent_combined_directories.session }}"
+    - "{{ rtorrent_combined_directories.watch }}"
   tags:
     - install
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,14 +32,14 @@
 
 - name: Create rtorrent directories
   file:
-    path: "{{ item }}"
+    path: "{{ item.path }}"
     state: directory
-    owner: "{{ rtorrent_dir_user  | ternary(rtorrent_dir_user,  rtorrent_user,  rtorrent_user)  }}"
-    group: "{{ rtorrent_dir_group | ternary(rtorrent_dir_group, rtorrent_group, rtorrent_group) }}"
+    owner: "{{ item.user  }}"
+    group: "{{ item.group }}"
   with_items:
-    - "{{ rtorrent_directory_download }}"
-    - "{{ rtorrent_directory_session }}"
-    - "{{ rtorrent_directory_watch }}"
+    - "{{ rtorrent_directories.download }}"
+    - "{{ rtorrent_directories.session }}"
+    - "{{ rtorrent_directories.watch }}"
   tags:
     - install
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -34,8 +34,8 @@
   file:
     path: "{{ item }}"
     state: directory
-    owner: "{{ rtorrent_user }}"
-    group: "{{ rtorrent_group }}"
+    owner: "{{ rtorrent_dir_user  | ternary(rtorrent_dir_user,  rtorrent_user,  rtorrent_user)  }}"
+    group: "{{ rtorrent_dir_group | ternary(rtorrent_dir_group, rtorrent_group, rtorrent_group) }}"
   with_items:
     - "{{ rtorrent_directory_download }}"
     - "{{ rtorrent_directory_session }}"

--- a/templates/rtorrent.rc.j2
+++ b/templates/rtorrent.rc.j2
@@ -16,10 +16,10 @@ throttle.global_down.max_rate.set_kb = {{ rtorrent_download_rate }}
 throttle.global_up.max_rate.set_kb = {{ rtorrent_upload_rate }}
 
 # Default directory to save the downloaded torrents.
-directory.default.set = {{ rtorrent_directory_download }}
+directory.default.set = {{ rtorrent_directories.download.path }}
 
 # Default session directory.
-session.path.set = {{ rtorrent_directory_session }}
+session.path.set = {{ rtorrent_directories.session.path }}
 
 # Watch a directory for new torrents, and stop those that have been deleted.
 schedule2 = {{ rtorrent_schedule_watch_directory }}

--- a/templates/rtorrent.rc.j2
+++ b/templates/rtorrent.rc.j2
@@ -1,58 +1,58 @@
 #{{ ansible_managed }}
 
 # Maximum and minimum number of peers to connect to per torrent.
-min_peers = {{ rtorrent_min_peers }}
-max_peers = {{ rtorrent_max_peers }}
+throttle.min_peers.normal.set = {{ rtorrent_min_peers }}
+throttle.max_peers.normal.set = {{ rtorrent_max_peers }}
 
 # Same as above but for seeding completed torrents (-1 = same as downloading)
-min_peers_seed = {{ rtorrent_min_peers_seed }}
-max_peers_seed = {{ rtorrent_max_peers_seed }}
+throttle.min_peers.seed.set = {{ rtorrent_min_peers_seed }}
+throttle.max_peers.seed.set = {{ rtorrent_max_peers_seed }}
 
 # Maximum number of simultanious uploads per torrent.
-max_uploads = {{ rtorrent_max_uploads }}
+throttle.max_uploads.set = {{ rtorrent_max_uploads }}
 
 # Global upload and download rate in KiB. "0" for unlimited.
-download_rate = {{ rtorrent_download_rate }}
-upload_rate = {{ rtorrent_upload_rate }}
+throttle.global_down.max_rate.set_kb = {{ rtorrent_download_rate }}
+throttle.global_up.max_rate.set_kb = {{ rtorrent_upload_rate }}
 
 # Default directory to save the downloaded torrents.
-directory = {{ rtorrent_directory_download }}
+directory.default.set = {{ rtorrent_directory_download }}
 
 # Default session directory.
-session = {{ rtorrent_directory_session }}
+session.path.set = {{ rtorrent_directory_session }}
 
 # Watch a directory for new torrents, and stop those that have been deleted.
-schedule = {{ rtorrent_schedule_watch_directory }}
-schedule = {{ rtorrent_schedule_untied_directory }}
+schedule2 = {{ rtorrent_schedule_watch_directory }}
+schedule2 = {{ rtorrent_schedule_untied_directory }}
 
 # Port range to use for listening.
-port_range = {{ rtorrent_port_range }}
+network.port_range.set = {{ rtorrent_port_range }}
 
 # Start opening ports at a random position within the port range.
-port_random = {{ rtorrent_port_random }}
+network.port_random.set = {{ rtorrent_port_random }}
 
 # Check hash for finished torrents.
-check_hash = {{ rtorrent_check_hash }}
+pieces.hash.on_completion.set = {{ rtorrent_check_hash }}
 
 # Set whetever the client should try to connect to UDP trackers.
-use_udp_trackers = {{ rtorrent_use_udp_trackers }}
+trackers.use_udp.set = {{ rtorrent_use_udp_trackers }}
 
 # Encryption options, set to none (default) or any combination of the following:
 # allow_incoming, try_outgoing, require, require_RC4, enable_retry, prefer_plaintext
-encryption = {{ rtorrent_encryption }}
+protocol.encryption.set = {{ rtorrent_encryption }}
 
 # Enable DHT support for trackerless torrents or when all trackers are down.
 # May be set to "disable" (completely disable DHT), "off" (do not start DHT),
 # "auto" (start and stop DHT as needed), or "on" (start DHT immediately).
 # The default is "off". For DHT to work, a session directory must be defined.
-dht = {{ rtorrent_dht }}
+dht.mode.set = {{ rtorrent_dht }}
 
 # UDP port to use for DHT.
-dht_port = {{ rtorrent_dht_port }}
+dht.port.set = {{ rtorrent_dht_port }}
 
 # Enable peer exchange (for torrents not marked private)
-peer_exchange = {{ rtorrent_peer_exchange }}
+protocol.pex.set = {{ rtorrent_peer_exchange }}
 
 {% if rtorrent_scgi_set %}
-scgi_port = {{ rtorrent_scgi_ip }}:{{ rtorrent_scgi_port }}
+network.scgi.open_port = {{ rtorrent_scgi_ip }}:{{ rtorrent_scgi_port }}
 {% endif %}

--- a/templates/rtorrent.rc.j2
+++ b/templates/rtorrent.rc.j2
@@ -16,10 +16,10 @@ throttle.global_down.max_rate.set_kb = {{ rtorrent_download_rate }}
 throttle.global_up.max_rate.set_kb = {{ rtorrent_upload_rate }}
 
 # Default directory to save the downloaded torrents.
-directory.default.set = {{ rtorrent_directories.download.path }}
+directory.default.set = {{ rtorrent_combined_directories.download.path }}
 
 # Default session directory.
-session.path.set = {{ rtorrent_directories.session.path }}
+session.path.set = {{ rtorrent_combined_directories.session.path }}
 
 # Watch a directory for new torrents, and stop those that have been deleted.
 schedule2 = {{ rtorrent_schedule_watch_directory }}

--- a/templates/rtorrent.service.initd.j2
+++ b/templates/rtorrent.service.initd.j2
@@ -25,7 +25,7 @@ OPTIONS=""
 
 # Check if rTorrent is running.
 check_running() {
-  if ! [ -s {{ rtorrent_directories.session.path }}/rtorrent.lock ];
+  if ! [ -s {{ rtorrent_combined_directories.session.path }}/rtorrent.lock ];
   then
     echo "rTorrent not running."
     exit 1;
@@ -34,7 +34,7 @@ check_running() {
 
 # Get the Process ID of rTorrent from the lockfile
 get_pid() {
-  PID=$(cat {{ rtorrent_directories.session.path }}/rtorrent.lock | awk -F: '{print($2)}' | sed "s/[^0-9]//g")
+  PID=$(cat {{ rtorrent_combined_directories.session.path }}/rtorrent.lock | awk -F: '{print($2)}' | sed "s/[^0-9]//g")
 }
 
 # Check if the config file is readable, check the session dir is readable
@@ -44,9 +44,9 @@ check_files() {
     echo "Cannot find readable config file {{ rtorrent_user_home }}/.rtorrent.rc"
     exit 1;
   fi
-  if ! [ -d "{{ rtorrent_directories.session.path }}" ];
+  if ! [ -d "{{ rtorrent_combined_directories.session.path }}" ];
   then
-    echo "Cannot find readable session directory {{ rtorrent_directories.session.path }}"
+    echo "Cannot find readable session directory {{ rtorrent_combined_directories.session.path }}"
   exit 1;
   fi
 }
@@ -54,7 +54,7 @@ check_files() {
 # Start rTorrent as a service within a tmux session
 do_start() {
   check_files;
-  if ! [ -s {{ rtorrent_directories.session.path }}/rtorrent.lock ];
+  if ! [ -s {{ rtorrent_combined_directories.session.path }}/rtorrent.lock ];
   then
     su - {{ rtorrent_user }} -c "/usr/bin/tmux -S {{ rtorrent_socket_path }} new-session -s rtorrent -n rTorrent -d ${SERVICE} ${OPTIONS}"
     sleep 2;
@@ -72,7 +72,7 @@ do_stop() {
   su - {{ rtorrent_user }} -c "/usr/bin/tmux -S {{ rtorrent_socket_path }}  send-keys -t rtorrent C-q"
   sleep 3;
   # Check if it closed or not
-  if ! [ -s {{ rtorrent_directories.session.path }}/rtorrent.lock ];
+  if ! [ -s {{ rtorrent_combined_directories.session.path }}/rtorrent.lock ];
   then
     echo "rTorrent stopped."
   else
@@ -80,7 +80,7 @@ do_stop() {
     # Make sure the pid doesn't belong to another process
     if ps ${PID} | grep -sq ${SERVICE};
     then
-      if ! [ -s {{ rtorrent_directories.session.path }}/rtorrent.lock ];
+      if ! [ -s {{ rtorrent_combined_directories.session.path }}/rtorrent.lock ];
       then
         echo "rTorrent stopped."
       else
@@ -89,12 +89,12 @@ do_stop() {
 
       # Wait 5 seconds to send the stop request to trackers
       sleep 5;
-      if ! [ -s {{ rtorrent_directories.session.path }}/rtorrent.lock ];
+      if ! [ -s {{ rtorrent_combined_directories.session.path }}/rtorrent.lock ];
       then
         echo "rTorrent stopped."
       else
         kill ${PID}
-        su - {{ rtorrent_user }} -c "rm -f {{ rtorrent_directories.session.path }}/rtorrent.lock"
+        su - {{ rtorrent_user }} -c "rm -f {{ rtorrent_combined_directories.session.path }}/rtorrent.lock"
         echo "rTorrent killed."
       fi
     else
@@ -120,7 +120,7 @@ do_info() {
   echo "- Base Path             : {{ rtorrent_user_home }}"
   echo "- Config File           : {{ rtorrent_user_home }}/.rtorrent.rc"
   echo "- tmux Session Name     : rtorrent"
-  echo "- rTorrent Session Path : {{ rtorrent_directories.session.path }}"
+  echo "- rTorrent Session Path : {{ rtorrent_combined_directories.session.path }}"
   echo "- Process ID            : "${PID}""
   echo "- Memory Usage          : $(expr ${RSS} / 1024) MB (${RSS} kB)"
 }

--- a/templates/rtorrent.service.initd.j2
+++ b/templates/rtorrent.service.initd.j2
@@ -25,7 +25,7 @@ OPTIONS=""
 
 # Check if rTorrent is running.
 check_running() {
-  if ! [ -s {{ rtorrent_directory_session }}/rtorrent.lock ];
+  if ! [ -s {{ rtorrent_directories.session.path }}/rtorrent.lock ];
   then
     echo "rTorrent not running."
     exit 1;
@@ -34,7 +34,7 @@ check_running() {
 
 # Get the Process ID of rTorrent from the lockfile
 get_pid() {
-  PID=$(cat {{ rtorrent_directory_session }}/rtorrent.lock | awk -F: '{print($2)}' | sed "s/[^0-9]//g")
+  PID=$(cat {{ rtorrent_directories.session.path }}/rtorrent.lock | awk -F: '{print($2)}' | sed "s/[^0-9]//g")
 }
 
 # Check if the config file is readable, check the session dir is readable
@@ -44,9 +44,9 @@ check_files() {
     echo "Cannot find readable config file {{ rtorrent_user_home }}/.rtorrent.rc"
     exit 1;
   fi
-  if ! [ -d "{{ rtorrent_directory_session }}" ];
+  if ! [ -d "{{ rtorrent_directories.session.path }}" ];
   then
-    echo "Cannot find readable session directory {{ rtorrent_directory_session }}"
+    echo "Cannot find readable session directory {{ rtorrent_directories.session.path }}"
   exit 1;
   fi
 }
@@ -54,7 +54,7 @@ check_files() {
 # Start rTorrent as a service within a tmux session
 do_start() {
   check_files;
-  if ! [ -s {{ rtorrent_directory_session }}/rtorrent.lock ];
+  if ! [ -s {{ rtorrent_directories.session.path }}/rtorrent.lock ];
   then
     su - {{ rtorrent_user }} -c "/usr/bin/tmux -S {{ rtorrent_socket_path }} new-session -s rtorrent -n rTorrent -d ${SERVICE} ${OPTIONS}"
     sleep 2;
@@ -72,7 +72,7 @@ do_stop() {
   su - {{ rtorrent_user }} -c "/usr/bin/tmux -S {{ rtorrent_socket_path }}  send-keys -t rtorrent C-q"
   sleep 3;
   # Check if it closed or not
-  if ! [ -s {{ rtorrent_directory_session }}/rtorrent.lock ];
+  if ! [ -s {{ rtorrent_directories.session.path }}/rtorrent.lock ];
   then
     echo "rTorrent stopped."
   else
@@ -80,7 +80,7 @@ do_stop() {
     # Make sure the pid doesn't belong to another process
     if ps ${PID} | grep -sq ${SERVICE};
     then
-      if ! [ -s {{ rtorrent_directory_session }}/rtorrent.lock ];
+      if ! [ -s {{ rtorrent_directories.session.path }}/rtorrent.lock ];
       then
         echo "rTorrent stopped."
       else
@@ -89,12 +89,12 @@ do_stop() {
 
       # Wait 5 seconds to send the stop request to trackers
       sleep 5;
-      if ! [ -s {{ rtorrent_directory_session }}/rtorrent.lock ];
+      if ! [ -s {{ rtorrent_directories.session.path }}/rtorrent.lock ];
       then
         echo "rTorrent stopped."
       else
         kill ${PID}
-        su - {{ rtorrent_user }} -c "rm -f {{ rtorrent_directory_session }}/rtorrent.lock"
+        su - {{ rtorrent_user }} -c "rm -f {{ rtorrent_directories.session.path }}/rtorrent.lock"
         echo "rTorrent killed."
       fi
     else
@@ -120,7 +120,7 @@ do_info() {
   echo "- Base Path             : {{ rtorrent_user_home }}"
   echo "- Config File           : {{ rtorrent_user_home }}/.rtorrent.rc"
   echo "- tmux Session Name     : rtorrent"
-  echo "- rTorrent Session Path : {{ rtorrent_directory_session }}"
+  echo "- rTorrent Session Path : {{ rtorrent_directories.session.path }}"
   echo "- Process ID            : "${PID}""
   echo "- Memory Usage          : $(expr ${RSS} / 1024) MB (${RSS} kB)"
 }

--- a/templates/rtorrent.service.systemd.j2
+++ b/templates/rtorrent.service.systemd.j2
@@ -13,7 +13,7 @@ ExecStartPost=/bin/sleep 3
 ExecStop=/usr/bin/tmux -S {{ rtorrent_socket_path }}  send-keys -t rtorrent C-q
 ExecStopPost=/bin/sleep 3
 ExecStopPost=-/usr/bin/tmux -S {{ rtorrent_socket_path }} kill-session -t rtorrent
-ExecStopPost=-/bin/rm -f {{ rtorrent_directories.session.path }}/rtorrent.lock
+ExecStopPost=-/bin/rm -f {{ rtorrent_combined_directories.session.path }}/rtorrent.lock
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/rtorrent.service.systemd.j2
+++ b/templates/rtorrent.service.systemd.j2
@@ -13,7 +13,7 @@ ExecStartPost=/bin/sleep 3
 ExecStop=/usr/bin/tmux -S {{ rtorrent_socket_path }}  send-keys -t rtorrent C-q
 ExecStopPost=/bin/sleep 3
 ExecStopPost=-/usr/bin/tmux -S {{ rtorrent_socket_path }} kill-session -t rtorrent
-ExecStopPost=-/bin/rm -f {{ rtorrent_directory_session }}/rtorrent.lock
+ExecStopPost=-/bin/rm -f {{ rtorrent_directories.session.path }}/rtorrent.lock
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
rTorrent 0.9 has [deprecated (renamed) many commands](https://github.com/rakshasa/rtorrent/wiki/rTorrent-0.9-Comprehensive-Command-list-(WIP)).

This pull request renames all the commands in the `templates/rtorrent.rc.j2` template.

Also, I had some specific needs for directory owner/permissions so I have included a rework for those settings that provide maximum flexibility. 

I can separate these changes if that would make things easier.